### PR TITLE
Import all members of each file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ plugin is for you!
 *Of course in the vast majority of cases you should just use normal import
 statements. Don't go overboard using this plugin.*
 
-You can import the **default members** of any matching module. Let's say you
+You can import the **members** of any matching module. Let's say you
 have a directory layout like this:
 
 * `index.js`

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function hasImportDefaultSpecifier (specifiers) {
 
 function makeImport (t, localName, src) {
   return t.importDeclaration([
-    t.importDefaultSpecifier(t.identifier(localName))
+    t.importNamespaceSpecifier(t.identifier(localName))
   ], t.stringLiteral(src))
 }
 

--- a/test/import-glob.js
+++ b/test/import-glob.js
@@ -81,15 +81,15 @@ test('throws when importing the default member', async t => {
 test('rewrites the import statement', t => {
   t.is(
     transform("import { foo, bar } from 'glob:./fixtures/multiple/*.txt'"),
-    `import foo from './fixtures/multiple/foo.txt';
-import bar from './fixtures/multiple/bar.txt';`)
+    `import * as foo from './fixtures/multiple/foo.txt';
+import * as bar from './fixtures/multiple/bar.txt';`)
 })
 
 test('does not require glob prefix', t => {
   t.is(
     transform("import { foo, bar } from './fixtures/multiple/*.txt'"),
-    `import foo from './fixtures/multiple/foo.txt';
-import bar from './fixtures/multiple/bar.txt';`)
+    `import * as foo from './fixtures/multiple/foo.txt';
+import * as bar from './fixtures/multiple/bar.txt';`)
 })
 
 test('does not transform standard import', t => {
@@ -101,54 +101,54 @@ test('does not transform standard import', t => {
 test('constructs the member by identifierfying the captured file name parts', t => {
   t.is(
     transform("import { fooBar, bazQux } from 'glob:./fixtures/extnames/*.txt'"),
-    `import fooBar from './fixtures/extnames/foo.bar.txt';
-import bazQux from './fixtures/extnames/baz.qux.txt';`)
+    `import * as fooBar from './fixtures/extnames/foo.bar.txt';
+import * as bazQux from './fixtures/extnames/baz.qux.txt';`)
 })
 
 test('constructs the member by identifierfying captured directory components, separating them by dollar signs', t => {
   t.is(
     transform("import { fooBar$baz, qux$quux } from 'glob:./fixtures/subdirectories/**/*.txt'"),
-    `import fooBar$baz from './fixtures/subdirectories/foo-bar/baz.txt';
-import qux$quux from './fixtures/subdirectories/qux/quux.txt';`)
+    `import * as fooBar$baz from './fixtures/subdirectories/foo-bar/baz.txt';
+import * as qux$quux from './fixtures/subdirectories/qux/quux.txt';`)
 })
 
 test('constructs the member by identifierfying captured directory components, without unnecessary underscores', t => {
   t.is(
     // eslint-disable-next-line max-len
     transform("import { noUnnecessaryUnderscores$new, noUnnecessaryUnderscores$42 } from 'glob:./fixtures/subdirectories/**/*.txt'"),
-    `import noUnnecessaryUnderscores$new from './fixtures/subdirectories/no-unnecessary-underscores/new.txt';
-import noUnnecessaryUnderscores$42 from './fixtures/subdirectories/no-unnecessary-underscores/42.txt';`)
+    `import * as noUnnecessaryUnderscores$new from './fixtures/subdirectories/no-unnecessary-underscores/new.txt';
+import * as noUnnecessaryUnderscores$42 from './fixtures/subdirectories/no-unnecessary-underscores/42.txt';`)
 
   t.is(
     transform("import { _new, _42 } from 'glob:./fixtures/necessary-underscores/*.txt'"),
-    `import _new from './fixtures/necessary-underscores/new.txt';
-import _42 from './fixtures/necessary-underscores/42.txt';`)
+    `import * as _new from './fixtures/necessary-underscores/new.txt';
+import * as _42 from './fixtures/necessary-underscores/42.txt';`)
 })
 
 test('normalizes the source path irrespective of pattern', t => {
   t.is(
     transform("import { fooBar } from 'glob:../test/fixtures/foo-bar/*.txt'"),
-    "import fooBar from './fixtures/foo-bar/foo-bar.txt';")
+    "import * as fooBar from './fixtures/foo-bar/foo-bar.txt';")
 })
 
 test('supports importing directories', t => {
   t.is(
     transform("import { extnames, fooBar } from 'glob:./fixtures/*'"),
-    `import extnames from './fixtures/extnames';
-import fooBar from './fixtures/foo-bar';`)
+    `import * as extnames from './fixtures/extnames';
+import * as fooBar from './fixtures/foo-bar';`)
 })
 
 test('supports aliasing members', t => {
   t.is(
     transform("import { fooBar as fb } from 'glob:./fixtures/foo-bar/*.txt'"),
-    "import fb from './fixtures/foo-bar/foo-bar.txt';")
+    "import * as fb from './fixtures/foo-bar/foo-bar.txt';")
 })
 
 test('supports importing the entire glob pattern as a namespace object', t => {
   t.is(
     transform("import * as members from 'glob:./fixtures/multiple/*.txt'"),
-    `import _members_bar from './fixtures/multiple/bar.txt';
-import _members_foo from './fixtures/multiple/foo.txt';
+    `import * as _members_bar from './fixtures/multiple/bar.txt';
+import * as _members_foo from './fixtures/multiple/foo.txt';
 const members = {
   bar: _members_bar,
   foo: _members_foo
@@ -166,8 +166,8 @@ import './fixtures/multiple/foo.txt';`)
 test('sub-extension removed because it is in the pattern', t => {
   t.is(
     transform("import * as members from 'glob:./fixtures/ext-from-pattern/*.foo.txt'"),
-    `import _members_one from './fixtures/ext-from-pattern/one.foo.txt';
-import _members_two from './fixtures/ext-from-pattern/two.foo.txt';
+    `import * as _members_one from './fixtures/ext-from-pattern/one.foo.txt';
+import * as _members_two from './fixtures/ext-from-pattern/two.foo.txt';
 const members = {
   one: _members_one,
   two: _members_two
@@ -178,8 +178,8 @@ Object.freeze(members);`)
 test('sub-extension not removed because it is not in the pattern', t => {
   t.is(
     transform("import * as members from 'glob:./fixtures/ext-from-pattern/*.txt'"),
-    `import _members_oneFoo from './fixtures/ext-from-pattern/one.foo.txt';
-import _members_twoFoo from './fixtures/ext-from-pattern/two.foo.txt';
+    `import * as _members_oneFoo from './fixtures/ext-from-pattern/one.foo.txt';
+import * as _members_twoFoo from './fixtures/ext-from-pattern/two.foo.txt';
 const members = {
   oneFoo: _members_oneFoo,
   twoFoo: _members_twoFoo
@@ -190,10 +190,10 @@ Object.freeze(members);`)
 test('test braced paths', t => {
   t.is(
     transform("import * as members from 'glob:./fixtures/use-dir-name/{!(sub),@(sub)/*}/foo.txt'"),
-    `import _members_one from './fixtures/use-dir-name/one/foo.txt';
-import _members_sub$four from './fixtures/use-dir-name/sub/four/foo.txt';
-import _members_sub$three from './fixtures/use-dir-name/sub/three/foo.txt';
-import _members_two from './fixtures/use-dir-name/two/foo.txt';
+    `import * as _members_one from './fixtures/use-dir-name/one/foo.txt';
+import * as _members_sub$four from './fixtures/use-dir-name/sub/four/foo.txt';
+import * as _members_sub$three from './fixtures/use-dir-name/sub/three/foo.txt';
+import * as _members_two from './fixtures/use-dir-name/two/foo.txt';
 const members = {
   one: _members_one,
   sub$four: _members_sub$four,
@@ -206,9 +206,9 @@ Object.freeze(members);`)
 test('extension should still be ommitted within brace', t => {
   t.is(
     transform("import * as members from 'glob:./fixtures/ext-from-pattern/*.{txt,csv}'"),
-    `import _members_oneFoo from './fixtures/ext-from-pattern/one.foo.txt';
-import _members_three from './fixtures/ext-from-pattern/three.csv';
-import _members_twoFoo from './fixtures/ext-from-pattern/two.foo.txt';
+    `import * as _members_oneFoo from './fixtures/ext-from-pattern/one.foo.txt';
+import * as _members_three from './fixtures/ext-from-pattern/three.csv';
+import * as _members_twoFoo from './fixtures/ext-from-pattern/two.foo.txt';
 const members = {
   oneFoo: _members_oneFoo,
   three: _members_three,
@@ -220,7 +220,7 @@ Object.freeze(members);`)
 test('includes directory names between * parts in the member names', t => {
   t.is(
     transform("import * as members from './fixtures/*/qux/*.txt'"),
-    `import _members_subdirectories$qux$quux from './fixtures/subdirectories/qux/quux.txt';
+    `import * as _members_subdirectories$qux$quux from './fixtures/subdirectories/qux/quux.txt';
 const members = {
   subdirectories$qux$quux: _members_subdirectories$qux$quux
 };
@@ -231,8 +231,8 @@ Object.freeze(members);`
 test('excludes non-captured brace expansion parts in the member names', t => {
   t.is(
     transform("import * as members from './fixtures/subdirectories/{foo-bar,qux}/*.txt'"),
-    `import _members_baz from './fixtures/subdirectories/foo-bar/baz.txt';
-import _members_quux from './fixtures/subdirectories/qux/quux.txt';
+    `import * as _members_baz from './fixtures/subdirectories/foo-bar/baz.txt';
+import * as _members_quux from './fixtures/subdirectories/qux/quux.txt';
 const members = {
   baz: _members_baz,
   quux: _members_quux


### PR DESCRIPTION
@novemberborn

After using the plugin extensively, I hit a case where the "default only" rule became rather limiting. I could separate the different exports as different files, but having them separate in some cases causes unnecessary confusion.

For example, I have:

reducer.js
```js
export default function(state, action) {
  if (someCondition) {
    const newState = {}
    return {
      ...state,
      someProp: "value"
    }
  }
  return state
}
```

types.js
```js
import PropTypes from "prop-types"

export default {
  someProp: PropTypes.string
}
```

Keeping the two creates an out-of-sight-out-of-mind effect. So what I could do is this:

reducer.js
```js
import PropTypes from "prop-types"

const types = export default {
  someProp: PropTypes.string
}

const reducer = function(state, action) {
  if (someCondition) {
    const newState = {}
    return {
      ...state,
      someProp: "value"
    }
  }
  return state
}

export default {types, reducer}
```

The issue with this is when I want just `reducer` in reducer.test.js:

```js
import reducer from "./reducer"
// reducer.reducer // .... ack!
// import {} from "./reducer" // doesn't work
```

So it makes more sense to have the plugin export everything so I can do this:

reducer.js
```js
import PropTypes from "prop-types"

export const types = export default {
  someProp: PropTypes.string
}

export const reducer = function(state, action) {
  if (someCondition) {
    const newState = {}
    return {
      ...state,
      someProp: "value"
    }
  }
  return state
}
```

And then in the test:

```js
import {reducer} from "./reducer"
// reducer // yay!
```

The following PR changes `importDefaultSpecifier` to `importNamespaceSpecifier` in `makeImport` so all exports can be reached.  The caveat is if you have a default export you'd have to append `.default`. Optionally we could check for `default` and use that, and then fallback to the whole export. In my use-case above I don't have a default export.